### PR TITLE
[KED-1066] Upgrade pylint to 2.4 and fix resulting breaking changes

### DIFF
--- a/features/steps/sh_run.py
+++ b/features/steps/sh_run.py
@@ -63,6 +63,7 @@ def run(
     """
     if isinstance(cmd, str) and split:
         cmd = shlex.split(cmd)
+    # pylint: disable=subprocess-run-check
     result = subprocess.run(
         cmd, input="", stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs
     )

--- a/kedro_airflow/plugin.py
+++ b/kedro_airflow/plugin.py
@@ -69,8 +69,8 @@ def create():
     )
 
     try:
-        # noqa:F401 pylint: disable=unused-import,import-outside-toplevel
-        from kedro.context import load_context
+        # pylint: disable=unused-import,import-outside-toplevel
+        from kedro.context import load_context  # noqa:F401
 
         context_compatibility_mode = False
     except ImportError:  # pragma: no coverage

--- a/kedro_airflow/plugin.py
+++ b/kedro_airflow/plugin.py
@@ -69,9 +69,8 @@ def create():
     )
 
     try:
-        from kedro.context import (  # noqa:F401 pylint: disable=unused-import
-            load_context,
-        )
+        # noqa:F401 pylint: disable=unused-import,import-outside-toplevel
+        from kedro.context import load_context
 
         context_compatibility_mode = False
     except ImportError:  # pragma: no coverage

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,7 +4,7 @@ black==v19.10.b0; python_version >= '3.6'
 flake8
 pre-commit>=1.17.0, <2.0
 psutil
-pylint>=2.3.1, <2.4.0 # 2.4.1 doesn't work for Python 3.5, and requires investigation.
+pylint>=2.4.4, <3.0
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Unpin pylint, needed to supress two new warnings

## How has this been tested?
make lint + ci

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Assigned myself to the PR
- [x] Added tests to cover my changes
- [x] Added new entries to the `RELEASE.md` file
