### PR TITLE
[KED-1404] Remove trufflehog pinned dependency in test_requirements.txt for Kedro-Airflow

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,12 +2,11 @@
 behave
 black==v19.10.b0; python_version >= '3.6'
 flake8
-gitdb2==3.0.0 # pin trufflehog dependency to get it working for now https://github.com/dxa4481/truffleHog/issues/200
 pre-commit>=1.17.0, <2.0
 psutil
 pylint>=2.4.4, <3.0
 pytest
 pytest-cov
 pytest-mock
-trufflehog>=2.0.99, <3.0
+trufflehog>=2.0.99
 wheel

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,5 +8,5 @@ pylint>=2.4.4, <3.0
 pytest
 pytest-cov
 pytest-mock
-trufflehog>=2.0.99
+trufflehog>=2.1.0, <3.0
 wheel


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
Fix for: https://github.com/quantumblacklabs/kedro/issues/248

## How has this been tested?
N/A

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Assigned myself to the PR
- [ ] Added tests to cover my changes
- [ ] Added new entries to the `RELEASE.md` file
